### PR TITLE
Activate communication in sequential case if requested by the grid

### DIFF
--- a/dune/pdelab/backend/istl/novlpistlsolverbackend.hh
+++ b/dune/pdelab/backend/istl/novlpistlsolverbackend.hh
@@ -21,6 +21,7 @@
 #include <dune/istl/solvers.hh>
 #include <dune/istl/superlu.hh>
 
+#include <dune/pdelab/common/gridtraits.hh>
 #include <dune/pdelab/constraints/common/constraints.hh>
 #include <dune/pdelab/gridfunctionspace/genericdatahandle.hh>
 #include <dune/pdelab/backend/istl/istlvectorbackend.hh>
@@ -95,7 +96,8 @@ namespace Dune {
 
         // accumulate y on border
         Dune::PDELab::AddDataHandle<GFS,Y> adddh(gfs,y);
-        if (gfs.gridView().comm().size()>1)
+        if (gfs.gridView().comm().size() > 1
+          || Dune::PDELab::requiresCommOnSequential<typename GFS::Traits::GridViewType::Grid>::v(gfs.gridView().grid()))
           gfs.gridView().communicate(adddh,Dune::InteriorBorder_InteriorBorder_Interface,Dune::ForwardCommunication);
       }
 
@@ -113,7 +115,7 @@ namespace Dune {
 
         // accumulate y on border
         Dune::PDELab::AddDataHandle<GFS,Y> adddh(gfs,y);
-        if (gfs.gridView().comm().size()>1)
+        if (gfs.gridView().comm().size() > 1)
           gfs.gridView().communicate(adddh,Dune::InteriorBorder_InteriorBorder_Interface,Dune::ForwardCommunication);
       }
 
@@ -172,7 +174,7 @@ namespace Dune {
       void make_consistent (X& x) const
       {
         Dune::PDELab::AddDataHandle<GFS,X> adddh(gfs,x);
-        if (gfs.gridView().comm().size()>1)
+        if (gfs.gridView().comm().size() > 1)
           gfs.gridView().communicate(adddh,Dune::InteriorBorder_InteriorBorder_Interface,Dune::ForwardCommunication);
       }
 
@@ -673,7 +675,8 @@ namespace Dune {
         jac.pre(z,r);
         jac.apply(z,r);
         jac.post(z);
-        if (gfs.gridView().comm().size()>1)
+        if (gfs.gridView().comm().size() > 1
+          || Dune::PDELab::requiresCommOnSequential<typename GFS::Traits::GridViewType::Grid>::v(gfs.gridView().grid()))
         {
           Dune::PDELab::AddDataHandle<GFS,V> adddh(gfs,z);
           gfs.gridView().communicate(adddh,Dune::InteriorBorder_InteriorBorder_Interface,Dune::ForwardCommunication);
@@ -772,7 +775,9 @@ namespace Dune {
         Solver<VectorType> solver(oop,psp,parsmoother,reduction,maxiter,verb);
         Dune::InverseOperatorResult stat;
         //make r consistent
-        if (gfs.gridView().comm().size()>1){
+        if (gfs.gridView().comm().size() > 1
+          || Dune::PDELab::requiresCommOnSequential<typename GFS::Traits::GridViewType::Grid>::v(gfs.gridView().grid()))
+        {
           Dune::PDELab::AddDataHandle<GFS,V> adddh(gfs,r);
           gfs.gridView().communicate(adddh,
                                      Dune::InteriorBorder_InteriorBorder_Interface,
@@ -987,7 +992,9 @@ namespace Dune {
 
         Dune::InverseOperatorResult stat;
         // make r consistent
-        if (gfs.gridView().comm().size()>1) {
+        if (gfs.gridView().comm().size() > 1
+          || Dune::PDELab::requiresCommOnSequential<typename GFS::Traits::GridViewType::Grid>::v(gfs.gridView().grid()))
+        {
           Dune::PDELab::AddDataHandle<GFS,V> adddh(gfs,r);
           gfs.gridView().communicate(adddh,
                                      Dune::InteriorBorder_InteriorBorder_Interface,

--- a/dune/pdelab/common/CMakeLists.txt
+++ b/dune/pdelab/common/CMakeLists.txt
@@ -10,6 +10,7 @@ install(FILES benchmarkhelper.hh
               functionwrappers.hh
               geometrywrapper.hh
               globaldofindex.hh
+              gridtraits.hh
               hostname.hh
               instationaryfilenamehelper.hh
               jacobiantocurl.hh

--- a/dune/pdelab/common/gridtraits.hh
+++ b/dune/pdelab/common/gridtraits.hh
@@ -1,0 +1,39 @@
+// -*- tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+// vi: set et ts=4 sw=2 sts=2:
+
+#ifndef DUNE_PDELAB_COMMON_GRIDTRAITS_HH
+#define DUNE_PDELAB_COMMON_GRIDTRAITS_HH
+
+namespace Dune {
+  namespace PDELab {
+
+    /** \brief Specialize with 'true' if implementation requires communication when running on a single process
+        \ingroup PDELabGridCapabilities
+     */
+    template<class Grid>
+    struct requiresCommOnSequential
+    {
+      static bool v(const Grid& grid) {
+        return false;
+      };
+    };
+
+    /** \brief YaspGrid needs communication for periodic boundaries to work (even when running sequentially)
+        \ingroup PDELabGridCapabilities
+     */
+    template<int dim, class Coordinates>
+    struct requiresCommOnSequential< YaspGrid<dim, Coordinates> >
+    {
+      static bool v(const YaspGrid<dim, Coordinates>& grid) {
+        for (int i = 0; i < dim; ++i) {
+          if (grid.isPeriodic(i))
+            return true;
+        }
+        return false;
+      };
+    };
+
+  } // end namespace PDELab
+} // end namespace Dune
+
+#endif // DUNE_PDELAB_COMMON_GRIDTRAITS_HH


### PR DESCRIPTION
- This is required for yaspgrid to support periodic boundaries in sequential case
- Uses the corresponding grid capability recently committed (see dune-grid pull request)

It works for me, however I'm not sure if this covers all necessary cases. Maybe dune/pdelab/backend/istl/ovlp_amg_dg_backend.hh needs those changes too?
